### PR TITLE
Correction de l'affichage du pseudo utilisateur sur la page détails

### DIFF
--- a/event-details.php
+++ b/event-details.php
@@ -65,7 +65,7 @@ if (isset($_GET["id"]) && !empty(trim($_GET["id"]))) {
             <?php if (!empty($event["user_image"])) : ?>
                 <img src="data:image/jpeg;base64,<?php echo $event["user_image"]; ?>" alt="Image de profil de l'utilisateur" style="width:100px;height:100px;">
             <?php endif; ?>
-            <p>événement de <br><?php echo htmlspecialchars($event["user_pseud"]); ?></p>
+            <p>événement de <br><?php echo htmlspecialchars($event["user_pseudo"]); ?></p>
         </div>
 
         <p class="description"><b>Description :</b> <?php echo htmlspecialchars($event["description"]); ?></p>


### PR DESCRIPTION
Il manquait un o à user_pseudo à la ligne 68 de event-details.php